### PR TITLE
Add C_vgatext_font_linedouble and remove auto-double for 8 high fonts…

### DIFF
--- a/rtl/generic/glue_bram_vgaf.vhd
+++ b/rtl/generic/glue_bram_vgaf.vhd
@@ -95,10 +95,11 @@ entity glue_bram is
 	C_vgatext_label: string := "f32c";
 	C_vgatext_mode: integer := 0;	-- 0=640x480, 1=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
 	C_vgatext_bits: integer := 4;
-	C_vgatext_mem: integer := 8;		-- 4 or 8 (4=80x25 mono, 8=up to 100x30 16 color)
-	C_vgatext_font_height: integer := 16;		-- font data height 8 (doubled vertically) or 16
-	C_vgatext_font_depth: integer := 7;			-- font char bits (7=128, 8=256 characters)
-	C_vgatext_char_height: integer := 16;		-- font cell height (text lines will be C_visible_height / C_CHAR_HEIGHT rounded down, 19=25 lines on 480p)
+	C_vgatext_mem: integer := 16;		-- 4 or 8 (4=80x25 mono, 8=up to 100x30 16 color)
+	C_vgatext_font_height: integer := 8;		-- font data height 8 (doubled vertically) or 16
+	C_vgatext_font_depth: integer := 8;			-- font char bits (7=128, 8=256 characters)
+	C_vgatext_font_linedouble: boolean := false;-- double each line of font (e.g. 8x8 font fills 8x16 cell)
+	C_vgatext_char_height: integer := 8;		-- font cell height (text lines will be C_visible_height / C_CHAR_HEIGHT rounded down, 19=25 lines on 480p)
 	C_vgatext_monochrome: boolean := false;		-- 4K ram mode
 	C_vgatext_palette: boolean := true;			-- false=fixed 16 color VGA palette or 16 writable 24-bit palette registers
 	C_vgatext_bitmap: boolean := true;			-- true for bitmap from sram/sdram
@@ -279,7 +280,7 @@ architecture Behavioral of glue_bram is
     signal from_vga_textmode: std_logic_vector(31 downto 0);
     signal vga_textmode_dmem_write: std_logic;
     signal vga_textmode_dmem_to_cpu: std_logic_vector(31 downto 0);
-    signal vga_textmode_addr: std_logic_vector(12 downto 2);
+    signal vga_textmode_addr: std_logic_vector(15 downto 2);
     signal vga_textmode_data: std_logic_vector(31 downto 0);
     signal vga_textmode_R: std_logic_vector(C_vgatext_bits-1 downto 0);
     signal vga_textmode_G: std_logic_vector(C_vgatext_bits-1 downto 0);
@@ -742,6 +743,7 @@ begin
         C_vgatext_bits          => C_vgatext_bits,
         C_vgatext_font_height   => C_vgatext_font_height,
         C_vgatext_font_depth    => C_vgatext_font_depth,
+		C_vgatext_font_linedouble => C_vgatext_font_linedouble,
         C_vgatext_char_height   => C_vgatext_char_height,
         C_vgatext_monochrome    => C_vgatext_monochrome,
         C_vgatext_palette       => C_vgatext_palette,

--- a/rtl/generic/glue_sdram.vhd
+++ b/rtl/generic/glue_sdram.vhd
@@ -110,7 +110,7 @@ entity glue_sdram is
 
 	C_vgatext: boolean := false;
 	C_vgatext_text: boolean := true;			-- enable text generation	
-	C_vgatext_mode: integer := 0;				-- 0=640x480, 1=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
+	C_vgatext_mode: integer := 0;				-- 0=640x480, 1=640x400, 2=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
 	C_vgatext_bits: integer := 4;
 	C_vgatext_label: string := "f32c";
 	C_vgatext_mem: integer := 4;				-- 4 or 8 (4=80x25 mono, 8=up to 100x30 16 color)
@@ -270,7 +270,7 @@ architecture Behavioral of glue_sdram is
 	signal vga_textmode_text_rewind: std_logic;
 	signal vga_textmode_dmem_write: std_logic;
 	signal vga_textmode_dmem_to_cpu: std_logic_vector(31 downto 0);
-	signal vga_textmode_bram_addr: std_logic_vector(12 downto 2);
+	signal vga_textmode_bram_addr: std_logic_vector(15 downto 2);
 	signal vga_textmode_bram_data: std_logic_vector(31 downto 0);
 	signal vga_textmode_R: std_logic_vector(C_vgatext_bits-1 downto 0);
 	signal vga_textmode_G: std_logic_vector(C_vgatext_bits-1 downto 0);

--- a/rtl/soc/vgahdmi/VGA_textmode.vhd
+++ b/rtl/soc/vgahdmi/VGA_textmode.vhd
@@ -29,7 +29,7 @@ use IEEE.NUMERIC_STD.ALL;
 
 entity VGA_textmode is
 	Generic (
-		C_vgatext_mode: integer := 0;				-- 0=640x480, 1=800x600 (you must still provide proper pixel clock for mode)
+		C_vgatext_mode: integer := 0;				-- 0=640x480, 1=640x400, 2=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
 		C_vgatext_bits: integer := 2;				-- bits per R G B for output (1 to 8)
 		C_vgatext_text: boolean := true;			-- enable text generation
 		C_vgatext_text_fifo: boolean := false;		-- true to use videofifo, else SRAM port
@@ -85,10 +85,11 @@ architecture Behavioral of VGA_textmode is
 		v_front_porch, v_sync_pulse, v_back_porch:	integer;
 		h_sync_polarity, v_sync_polarity:			std_logic;
 	end record;
-	type video_mode_array_t is array (0 to 1) of video_mode_t;
+	type video_mode_array_t is array (0 to 2) of video_mode_t;
 	constant vmode: video_mode_array_t :=
 	(
-		(	pixel_clock_Hz	=>	25000000,	-- actually 25175000, but 25Mhz is more common with FPGAs (and works on virtually all monitors)
+		(	-- 640x480 @ ~60Hz 
+			pixel_clock_Hz	=>	25000000,	-- 640x480 @ ~60Hz actually 25175000, but 25Mhz is more common with FPGAs (and works on virtually all monitors)
 			visible_width	=>	640,
 			visible_height	=>	480,
 			h_front_porch	=>	16,
@@ -100,7 +101,21 @@ architecture Behavioral of VGA_textmode is
 			h_sync_polarity	=>	'0',
 			v_sync_polarity	=>	'0'
 		),
-		(	pixel_clock_Hz	=>	40000000,
+		(	-- 640x400 @ ~70Hz
+			pixel_clock_Hz	=>	25000000,	-- 640x400 @ ~70Hz (actually 25175000, but 25Mhz is more common with FPGAs (and works on virtually all monitors)
+			visible_width	=>	640,
+			visible_height	=>	400,
+			h_front_porch	=>	16,
+			h_sync_pulse	=>	96,
+			h_back_porch	=>	48,
+			v_front_porch	=>	12,
+			v_sync_pulse	=>	2,
+			v_back_porch	=>	35,
+			h_sync_polarity	=>	'0',
+			v_sync_polarity	=>	'1'
+		),
+		(	-- 800x600 @ ~60Hz
+			pixel_clock_Hz	=>	40000000,
 			visible_width	=>	800,
 			visible_height	=>	600,
 			h_front_porch	=>	40,

--- a/rtl/soc/vgahdmi/VGA_textmode_bram.vhd
+++ b/rtl/soc/vgahdmi/VGA_textmode_bram.vhd
@@ -44,7 +44,7 @@ entity VGA_textmode_bram is
     );
     port(
 	clk: in std_logic;
-	imem_addr: in std_logic_vector(12 downto 2);
+	imem_addr: in std_logic_vector(15 downto 2);
 	imem_data_out: out std_logic_vector(31 downto 0);
 	dmem_write: in std_logic;
 	dmem_byte_sel: in std_logic_vector(3 downto 0);


### PR DESCRIPTION
….  Also expand BRAM address space to allow 64KB of VGA BRAM memory.

This allows 8x8 "teeny" fonts.  To test, use f32c_VGAConsoleTest, but set "text_mem" to 0x40000000.
This needs 16KB of BRAM for 80x60 (9600 bytes text+color) so also expanded BRAM address bits (max 64KB now and optimizer should remove unused ones).  Also BRAM text in scarab works fine (with read+write bus).