### PR TITLE
Fix up VGA textmode generics.  Add all generics.  Fix comments, inden…

### DIFF
--- a/rtl/generic/glue_sdram.vhd
+++ b/rtl/generic/glue_sdram.vhd
@@ -108,25 +108,26 @@ entity glue_sdram is
 	C_vgahdmi_mem_kb: integer := 10; -- mem size of BRAM framebuffer if BRAM is used
 	C_vgahdmi_test_picture: integer := 0; -- 0: disable 1:show test picture in Red and Blue channel
 
-	C_vgatext: boolean := false;
-	C_vgatext_text: boolean := true;			-- enable text generation	
-	C_vgatext_mode: integer := 0;				-- 0=640x480, 1=640x400, 2=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
-	C_vgatext_bits: integer := 4;
-	C_vgatext_label: string := "f32c";
-	C_vgatext_mem: integer := 4;				-- 4 or 8 (4=80x25 mono, 8=up to 100x30 16 color)
-	C_vgatext_text_fifo: boolean := true;		-- true to use videofifo for text+color, else SRAM port
-        C_vgatext_text_fifo_step: integer := (80*2)/4; -- step for the fifo refill and rewind
-        C_vgatext_text_fifo_width: integer := 6; -- width of FIFO address space (default=4) len = 2^width * 4 byte
-	C_vgatext_font_height: integer := 16;		-- font data height 8 (doubled vertically) or 16
-	C_vgatext_font_depth: integer := 8;			-- font char bits (7=128, 8=256 characters)
-	C_vgatext_char_height: integer := 16;		-- font cell height (text lines will be C_visible_height / C_CHAR_HEIGHT rounded down, 19=25 lines on 480p)
-	C_vgatext_monochrome: boolean := false;		-- 4K ram mode
-	C_vgatext_palette: boolean := true;			-- false=fixed 16 color VGA palette or 16 writable 24-bit palette registers
-	C_vgatext_bitmap: boolean := true;			-- true for bitmap from sram/sdram
-	C_vgatext_bitmap_fifo: boolean := true;		-- true to use videofifo for bitmap, else SRAM port
-        C_vgatext_bitmap_fifo_step: integer := 0; -- step for the fifo refill and rewind
-        C_vgatext_bitmap_fifo_width: integer := 8; -- width of FIFO address space (default=4) len = 2^width * 4 byte
-	C_vgatext_bitmap_depth: integer := 8;		-- bits per pixel (1, 2, 4, 8)
+	C_vgatext: boolean := false; -- Xark's feature-rich bitmap+textmode VGA
+		C_vgatext_label: string := "f32c";			-- default banner in screen memory
+		C_vgatext_mode: integer := 0;				-- 0=640x480, 1=640x400, 2=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
+		C_vgatext_bits: integer := 2;				-- bits of VGA color per red, green, blue gun (e.g., 1=8, 2=64 and 4=4096 total colors possible)
+		C_vgatext_mem: integer := 4;				-- BRAM size 1, 2, 4, 8 or 16 depending on font and screen size/memory
+		C_vgatext_palette: boolean := false;			-- true for run-time color look-up table, else 16 fixed VGA color palette
+		C_vgatext_text: boolean := true;			-- enable text generation	
+			C_vgatext_monochrome: boolean := true;		-- true for 2-color text for whole screen, else additional color attribute byte per character
+			C_vgatext_font_height: integer := 16;		-- font data height 8 or 16 for 8x8 or 8x16 font
+			C_vgatext_char_height: integer := 16;		-- font cell height (text lines will be C_visible_height / C_CHAR_HEIGHT rounded down, 19=25 lines on 480p)
+			C_vgatext_font_linedouble: boolean := false; -- double font height by doubling each line (e.g., so 8x8 font fills 8x16 cell)
+			C_vgatext_font_depth: integer := 8;			-- font char bits 7 for 128 characters or 8 for 256 characters
+			C_vgatext_text_fifo: boolean := true;		-- true to use videofifo for text+color, else BRAM for text+color memory
+				C_vgatext_text_fifo_step: integer := (80*2)/4; -- step for the fifo refill and rewind
+				C_vgatext_text_fifo_width: integer := 6; 	-- width of FIFO address space (default=4) len = 2^width * 4 byte
+		C_vgatext_bitmap: boolean := true;			-- true to enable bitmap generation
+		C_vgatext_bitmap_depth: integer := 8;		-- bitmap bits per pixel (1, 2, 4, 8)
+			C_vgatext_bitmap_fifo: boolean := true;		-- true to use videofifo, else SRAM port for bitmap memory
+				C_vgatext_bitmap_fifo_step: integer := 0;	-- bitmap step for the fifo refill and rewind (0 unless repeating lines)
+				C_vgatext_bitmap_fifo_width: integer := 8;	-- bitmap width of FIFO address space len = 2^width * 4 byte
 
 	C_pcm: boolean := true;
 	C_fmrds: boolean := false; -- enable FM/RDS output to fm_antenna
@@ -925,18 +926,19 @@ begin
 	if C_vgatext generate
 	vga_video: entity work.VGA_textmode
 	generic map (
-		C_vgatext_text			=>	C_vgatext_text,
-		C_vgatext_text_fifo		=>	C_vgatext_text_fifo,
 		C_vgatext_mode			=>	C_vgatext_mode,
 		C_vgatext_bits			=>	C_vgatext_bits,
-		C_vgatext_font_height	=>	C_vgatext_font_height,
-		C_vgatext_font_depth	=>	C_vgatext_font_depth,
-		C_vgatext_char_height	=>	C_vgatext_char_height,
-		C_vgatext_monochrome	=>	C_vgatext_monochrome,
 		C_vgatext_palette		=>	C_vgatext_palette,
+		C_vgatext_text			=>	C_vgatext_text,
+		C_vgatext_monochrome	=>	C_vgatext_monochrome,
+		C_vgatext_font_height	=>	C_vgatext_font_height,
+		C_vgatext_char_height	=>	C_vgatext_char_height,
+		C_vgatext_font_linedouble => C_vgatext_font_linedouble,
+		C_vgatext_font_depth	=>	C_vgatext_font_depth,
+		C_vgatext_text_fifo		=>	C_vgatext_text_fifo,
 		C_vgatext_bitmap		=>	C_vgatext_bitmap,
-		C_vgatext_bitmap_fifo	=>	C_vgatext_bitmap_fifo,
-		C_vgatext_bitmap_depth	=>	C_vgatext_bitmap_depth
+		C_vgatext_bitmap_depth	=>	C_vgatext_bitmap_depth,
+		C_vgatext_bitmap_fifo	=>	C_vgatext_bitmap_fifo
 	)
 	port map (
 		clk => clk, ce => vga_textmode_ce, addr => dmem_addr(4 downto 2),

--- a/rtl/xilinx/scarab_ms6p_toplevel_bram_hdmi.vhd
+++ b/rtl/xilinx/scarab_ms6p_toplevel_bram_hdmi.vhd
@@ -39,7 +39,7 @@ use work.f32c_pack.all;
 
 
 entity glue is
-    generic (
+	generic (
 	-- ISA: either ARCH_MI32 or ARCH_RV32
 	C_arch: integer := ARCH_MI32;
 	C_debug: boolean := false;
@@ -51,15 +51,33 @@ entity glue is
 	C_mem_size: integer := 32; -- KB
 	C_vgahdmi: boolean := false;
 	C_vgahdmi_mem_kb: integer := 38; -- KB 38K full mono 640x480
-	C_vgatext: boolean := true; -- Xark's feature-ritch bitmap+textmode VGA
-	C_vgatext_label: string := "f32c: miniSpartan6+ MIPS compatible soft-core 100MHz 32KB BRAM";
-	C_vgatext_bitmap: boolean := false;
-	C_vgatext_bitmap_fifo: boolean := false;		-- true to use videofifo, else SRAM port
+	
+	C_vgatext: boolean := true; -- Xark's feature-rich bitmap+textmode VGA
+		C_vgatext_label: string :=  "f32c: miniSpartan6+ MIPS compatible soft-core 100MHz 32KB BRAM";	-- default banner in screen memory
+		C_vgatext_mode: integer := 0;				-- 0=640x480, 1=640x400, 2=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
+		C_vgatext_bits: integer := 2;				-- bits of VGA color per red, green, blue gun (e.g., 1=8, 2=64 and 4=4096 total colors possible)
+		C_vgatext_mem: integer := 8;				-- BRAM size 1, 2, 4, 8 or 16 depending on font and screen size/memory
+		C_vgatext_palette: boolean := false;			-- true for run-time color look-up table, else 16 fixed VGA color palette
+		C_vgatext_text: boolean := true;			-- enable text generation	
+			C_vgatext_monochrome: boolean := false;		-- true for 2-color text for whole screen, else additional color attribute byte per character
+			C_vgatext_font_height: integer := 16;		-- font data height 8 or 16 for 8x8 or 8x16 font
+			C_vgatext_char_height: integer := 16;		-- font cell height (text lines will be C_visible_height / C_CHAR_HEIGHT rounded down, 19=25 lines on 480p)
+			C_vgatext_font_linedouble: boolean := false; -- double font height by doubling each line (e.g., so 8x8 font fills 8x16 cell)
+			C_vgatext_font_depth: integer := 7;			-- font char bits 7 for 128 characters or 8 for 256 characters
+			C_vgatext_text_fifo: boolean := false;		-- true to use videofifo for text+color, else BRAM for text+color memory
+				C_vgatext_text_fifo_step: integer := (80*2)/4; -- step for the fifo refill and rewind
+				C_vgatext_text_fifo_width: integer := 6; 	-- width of FIFO address space (default=4) len = 2^width * 4 byte
+		C_vgatext_bitmap: boolean := false;			-- true to enable bitmap generation
+		C_vgatext_bitmap_depth: integer := 8;		-- bitmap bits per pixel (1, 2, 4, 8)
+			C_vgatext_bitmap_fifo: boolean := false;		-- true to use videofifo, else SRAM port for bitmap memory
+				C_vgatext_bitmap_fifo_step: integer := 0;	-- bitmap step for the fifo refill and rewind (0 unless repeating lines)
+				C_vgatext_bitmap_fifo_width: integer := 8;	-- bitmap width of FIFO address space len = 2^width * 4 byte
+	
 	C_fmrds: boolean := true;
 	C_rds_msg_len: integer := 260; -- bytes of RAM for RDS binary message
-        C_fmdds_hz: integer := 250000000; -- Hz clk_fmdds (>2*108 MHz, e.g. 250 MHz, 325 MHz)
-        C_rds_clock_multiply: integer := 57; -- multiply and divide from cpu clk 100 MHz
-        C_rds_clock_divide: integer := 3125; -- to get 1.824 MHz for RDS logic
+		C_fmdds_hz: integer := 250000000; -- Hz clk_fmdds (>2*108 MHz, e.g. 250 MHz, 325 MHz)
+		C_rds_clock_multiply: integer := 57; -- multiply and divide from cpu clk 100 MHz
+		C_rds_clock_divide: integer := 3125; -- to get 1.824 MHz for RDS logic
 	-- warning long compile time on ISE 14.7
 	-- C_pids = 2: 1 hour
 	-- C_pids = 4: 4 hours
@@ -72,8 +90,8 @@ entity glue is
 	C_spi: integer := 2;
 	C_gpio: integer := 32;
 	C_simple_io: boolean := true
-    );
-    port (
+	);
+	port (
 	clk_50MHz: in std_logic;
 	rs232_tx: out std_logic;
 	rs232_rx: in std_logic;
@@ -88,66 +106,82 @@ entity glue is
 	TMDS_out_P, TMDS_out_N: out std_logic_vector(2 downto 0);
 	TMDS_out_CLK_P, TMDS_out_CLK_N: out std_logic;
 	sw: in std_logic_vector(4 downto 1)
-    );
+	);
 end glue;
 
 architecture Behavioral of glue is
-    signal clk, rs232_break: std_logic;
-    signal btns: std_logic_vector(1 downto 0);
-    signal clk_25MHz, clk_250MHz: std_logic := '0';
-    signal tmds_out_rgb: std_logic_vector(2 downto 0);
+	signal clk, rs232_break: std_logic;
+	signal btns: std_logic_vector(1 downto 0);
+	signal clk_25MHz, clk_250MHz: std_logic := '0';
+	signal tmds_out_rgb: std_logic_vector(2 downto 0);
 begin
-    -- clock synthesizer: Xilinx Spartan-6 specific
-    
-    clk112: if C_clk_freq = 112 generate
-    clkgen112: entity work.pll_50M_112M5
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk
-    );
-    end generate;
+	-- clock synthesizer: Xilinx Spartan-6 specific
+	
+	clk112: if C_clk_freq = 112 generate
+	clkgen112: entity work.pll_50M_112M5
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk
+	);
+	end generate;
 
-    clk100: if C_clk_freq = 100 generate
-    clkgen100: entity work.pll_50M_100M_25M_250M
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk, clk_out2 => clk_25MHz, clk_out3 => clk_250MHz
-    );
-    end generate;
+	clk100: if C_clk_freq = 100 generate
+	clkgen100: entity work.pll_50M_100M_25M_250M
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk, clk_out2 => clk_25MHz, clk_out3 => clk_250MHz
+	);
+	end generate;
 
-    clk81: if C_clk_freq = 81 generate
-    clkgen81: entity work.pll_50M_81M25
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk
-    );
-    end generate;
+	clk81: if C_clk_freq = 81 generate
+	clkgen81: entity work.pll_50M_81M25
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk
+	);
+	end generate;
 
-    clk50: if C_clk_freq = 50 generate
-      clk <= clk_50MHz;
-    end generate;
+	clk50: if C_clk_freq = 50 generate
+	  clk <= clk_50MHz;
+	end generate;
 
-    -- reset hard-block: Xilinx Spartan-6 specific
-    reset: startup_spartan6
-    port map (
+	-- reset hard-block: Xilinx Spartan-6 specific
+	reset: startup_spartan6
+	port map (
 	clk => clk, gsr => rs232_break, gts => rs232_break,
 	keyclearb => '0'
-    );
+	);
 
-    -- generic BRAM glue
-    glue_bram: entity work.glue_bram
-    generic map (
+	-- generic BRAM glue
+	glue_bram: entity work.glue_bram
+	generic map (
 	C_arch => C_arch,
 	C_clk_freq => C_clk_freq,
 	C_mem_size => C_mem_size,
 	C_vgahdmi => C_vgahdmi,
 	C_vgahdmi_mem_kb => C_vgahdmi_mem_kb,
-        C_vgatext => C_vgatext,
+	C_vgatext => C_vgatext,
 	C_vgatext_label => C_vgatext_label,
-        C_vgatext_bitmap => C_vgatext_bitmap,
+	C_vgatext_mode => C_vgatext_mode,
+	C_vgatext_bits => C_vgatext_bits,
+	C_vgatext_mem => C_vgatext_mem,
+	C_vgatext_palette => C_vgatext_palette,
+	C_vgatext_text => C_vgatext_text,
+	C_vgatext_monochrome => C_vgatext_monochrome,
+	C_vgatext_font_height => C_vgatext_font_height,
+	C_vgatext_char_height => C_vgatext_char_height,
+	C_vgatext_font_linedouble => C_vgatext_font_linedouble,
+	C_vgatext_font_depth => C_vgatext_font_depth,
+	C_vgatext_text_fifo => C_vgatext_text_fifo,
+	C_vgatext_text_fifo_step => C_vgatext_text_fifo_step,
+	C_vgatext_text_fifo_width => C_vgatext_text_fifo_width,
+	C_vgatext_bitmap => C_vgatext_bitmap,
+	C_vgatext_bitmap_depth => C_vgatext_bitmap_depth,
 	C_vgatext_bitmap_fifo => C_vgatext_bitmap_fifo,
+	C_vgatext_bitmap_fifo_step => C_vgatext_bitmap_fifo_step,
+	C_vgatext_bitmap_fifo_width => C_vgatext_bitmap_fifo_width,
 	C_fmrds => C_fmrds,
 	C_fmdds_hz => C_fmdds_hz,
 	C_rds_msg_len => C_rds_msg_len,
-        C_rds_clock_multiply => C_rds_clock_multiply,
-        C_rds_clock_divide => C_rds_clock_divide,
+		C_rds_clock_multiply => C_rds_clock_multiply,
+		C_rds_clock_divide => C_rds_clock_divide,
 	C_gpio => C_gpio,
 	C_sio => C_sio,
 	C_spi => C_spi,
@@ -158,8 +192,8 @@ begin
 	C_pid_precision => C_pid_precision, -- fixed point PID precision
 	C_pid_pwm_bits => C_pid_pwm_bits, -- clock divider bits define PWM output frequency
 	C_debug => C_debug
-    )
-    port map (
+	)
+	port map (
 	clk => clk,
 	clk_25MHz => clk_25MHz, -- pixel clock
 	clk_250MHz => clk_250MHz, -- tmds clock
@@ -181,17 +215,17 @@ begin
 	simple_in(31 downto 20) => open,
 	fm_antenna => portd(0),
 	tmds_out_rgb => tmds_out_rgb
-    );
-    
-    -- differential output buffering for HDMI clock and video
-    hdmi_output: entity work.hdmi_out
-      port map (
-        tmds_in_clk => clk_25MHz,
-        tmds_out_clk_p => tmds_out_clk_p,
-        tmds_out_clk_n => tmds_out_clk_n,
-        tmds_in_rgb => tmds_out_rgb,
-        tmds_out_rgb_p => tmds_out_p,
-        tmds_out_rgb_n => tmds_out_n
-      );
+	);
+	
+	-- differential output buffering for HDMI clock and video
+	hdmi_output: entity work.hdmi_out
+	  port map (
+		tmds_in_clk => clk_25MHz,
+		tmds_out_clk_p => tmds_out_clk_p,
+		tmds_out_clk_n => tmds_out_clk_n,
+		tmds_in_rgb => tmds_out_rgb,
+		tmds_out_rgb_p => tmds_out_p,
+		tmds_out_rgb_n => tmds_out_n
+	  );
 
 end Behavioral;

--- a/rtl/xilinx/scarab_ms6p_toplevel_sdram.vhd
+++ b/rtl/xilinx/scarab_ms6p_toplevel_sdram.vhd
@@ -38,7 +38,7 @@ use work.f32c_pack.all;
 
 
 entity glue is
-    generic (
+	generic (
 	-- ISA: either ARCH_MI32 or ARCH_RV32
 	C_arch: integer := ARCH_MI32;
 	C_debug: boolean := false;
@@ -47,32 +47,52 @@ entity glue is
 	C_clk_freq: integer := 100;
 	-- SoC configuration options
 	C_mem_size: integer := 8; -- bootloader area
-        C_icache_expire: boolean := false; -- false: normal i-cache, true: passthru buggy i-cache
-        C_icache_size: integer := 32; -- 0, 2, 4, 8, 16, 32 KBytes
-        C_dcache_size: integer := 8; -- 0, 2, 4, 8, 16, 32 KBytes
-        C_sdram_separate_arbiter: boolean := false;
+		C_icache_expire: boolean := false; -- false: normal i-cache, true: passthru buggy i-cache
+		C_icache_size: integer := 32; -- 0, 2, 4, 8, 16, 32 KBytes
+		C_dcache_size: integer := 8; -- 0, 2, 4, 8, 16, 32 KBytes
+		C_sdram_separate_arbiter: boolean := false;
 	C_ram_emu_addr_width: integer := 0; -- RAM emulation (0:disable, 11:8K, 12:16K ...)
 	C_ram_emu_wait_states: integer := 2; -- 0 doesn't work, 1 and more works
-        C_vgahdmi: boolean := false; -- old Emard's bitmap-only VGA
-	C_vgatext: boolean := true; -- Xark's feature-ritch bitmap+textmode VGA
-	C_vgatext_label: string := "f32c: miniSpartan6+ MIPS compatible soft-core 100MHz 32MB SDRAM";
+		C_vgahdmi: boolean := false; -- old Emard's bitmap-only VGA
+
+	C_vgatext: boolean := true; -- Xark's feature-rich bitmap+textmode VGA
+		C_vgatext_label: string := "f32c: miniSpartan6+ MIPS compatible soft-core 100MHz 32MB SDRAM";	-- default banner in screen memory
+		C_vgatext_mode: integer := 0;				-- 0=640x480, 1=640x400, 2=800x600 (you must still provide proper pixel clock [25MHz or 40Mhz])
+		C_vgatext_bits: integer := 4;				-- bits of VGA color per red, green, blue gun (e.g., 1=8, 2=64 and 4=4096 total colors possible)
+		C_vgatext_mem: integer := 4;				-- BRAM size 1, 2, 4, 8 or 16 depending on font and screen size/memory
+		C_vgatext_palette: boolean := true;			-- true for run-time color look-up table, else 16 fixed VGA color palette
+		C_vgatext_text: boolean := true;			-- enable text generation	
+			C_vgatext_monochrome: boolean := false;		-- true for 2-color text for whole screen, else additional color attribute byte per character
+			C_vgatext_font_height: integer := 16;		-- font data height 8 or 16 for 8x8 or 8x16 font
+			C_vgatext_char_height: integer := 16;		-- font cell height (text lines will be C_visible_height / C_CHAR_HEIGHT rounded down, 19=25 lines on 480p)
+			C_vgatext_font_linedouble: boolean := false; -- double font height by doubling each line (e.g., so 8x8 font fills 8x16 cell)
+			C_vgatext_font_depth: integer := 8;			-- font char bits 7 for 128 characters or 8 for 256 characters
+			C_vgatext_text_fifo: boolean := true;		-- true to use videofifo for text+color, else BRAM for text+color memory
+				C_vgatext_text_fifo_step: integer := (80*2)/4; -- step for the fifo refill and rewind
+				C_vgatext_text_fifo_width: integer := 6; 	-- width of FIFO address space (default=4) len = 2^width * 4 byte
+		C_vgatext_bitmap: boolean := true;			-- true to enable bitmap generation
+		C_vgatext_bitmap_depth: integer := 8;		-- bitmap bits per pixel (1, 2, 4, 8)
+			C_vgatext_bitmap_fifo: boolean := true;		-- true to use videofifo, else SRAM port for bitmap memory
+				C_vgatext_bitmap_fifo_step: integer := 0;	-- bitmap step for the fifo refill and rewind (0 unless repeating lines)
+				C_vgatext_bitmap_fifo_width: integer := 8;	-- bitmap width of FIFO address space len = 2^width * 4 byte
+
 	C_fmrds: boolean := true;
 	C_sio: integer := 1;
 	C_spi: integer := 2;
 	C_gpio: integer := 32
-    );
-    port (
+	);
+	port (
 	clk_50MHz: in std_logic;
-        sdram_clk   : out std_logic;
-        sdram_cke   : out std_logic;
-        sdram_csn   : out std_logic;
-        sdram_rasn  : out std_logic;
-        sdram_casn  : out std_logic;
-        sdram_wen   : out std_logic;
-        sdram_a     : out std_logic_vector (12 downto 0);
-        sdram_ba    : out std_logic_vector(1 downto 0);
-        sdram_dqm   : out std_logic_vector(1 downto 0);
-        sdram_d     : inout std_logic_vector (15 downto 0);
+		sdram_clk   : out std_logic;
+		sdram_cke   : out std_logic;
+		sdram_csn   : out std_logic;
+		sdram_rasn  : out std_logic;
+		sdram_casn  : out std_logic;
+		sdram_wen   : out std_logic;
+		sdram_a     : out std_logic_vector (12 downto 0);
+		sdram_ba    : out std_logic_vector(1 downto 0);
+		sdram_dqm   : out std_logic_vector(1 downto 0);
+		sdram_d     : inout std_logic_vector (15 downto 0);
 	rs232_tx: out std_logic;
 	rs232_rx: in std_logic;
 	flash_cs, flash_cclk, flash_mosi: out std_logic;
@@ -88,74 +108,74 @@ entity glue is
 	TMDS_out_P, TMDS_out_N: out std_logic_vector(2 downto 0);
 	TMDS_out_CLK_P, TMDS_out_CLK_N: out std_logic;
 	sw: in std_logic_vector(4 downto 1)
-    );
+	);
 end glue;
 
 architecture Behavioral of glue is
-    signal clk, sdram_clk_internal: std_logic;
-    signal clk_25MHz, clk_250MHz: std_logic := '0';
-    signal rs232_break: std_logic;
-    signal btns: std_logic_vector(1 downto 0);
-    signal tmds_out_rgb: std_logic_vector(2 downto 0);
+	signal clk, sdram_clk_internal: std_logic;
+	signal clk_25MHz, clk_250MHz: std_logic := '0';
+	signal rs232_break: std_logic;
+	signal btns: std_logic_vector(1 downto 0);
+	signal tmds_out_rgb: std_logic_vector(2 downto 0);
 begin
-    -- clock synthesizer: Xilinx Spartan-6 specific
+	-- clock synthesizer: Xilinx Spartan-6 specific
 
-    clk125: if C_clk_freq = 125 generate
-    clkgen125: entity work.pll_50M_250M_125M_25M
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk_250MHz, clk_out2 => clk, clk_out3 => clk_25MHz
-    );
-    end generate;
+	clk125: if C_clk_freq = 125 generate
+	clkgen125: entity work.pll_50M_250M_125M_25M
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk_250MHz, clk_out2 => clk, clk_out3 => clk_25MHz
+	);
+	end generate;
 
-    clk112: if C_clk_freq = 112 generate
-    clkgen112: entity work.pll_50M_112M5
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk
-    );
-    end generate;
+	clk112: if C_clk_freq = 112 generate
+	clkgen112: entity work.pll_50M_112M5
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk
+	);
+	end generate;
 
-    clk111: if C_clk_freq = 111 generate
-    clkgen111: entity work.pll_50M_250M_111M11_25M
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk_250MHz, clk_out2 => clk, clk_out3 => clk_25MHz
-    );
-    end generate;
+	clk111: if C_clk_freq = 111 generate
+	clkgen111: entity work.pll_50M_250M_111M11_25M
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk_250MHz, clk_out2 => clk, clk_out3 => clk_25MHz
+	);
+	end generate;
 
-    clk100: if C_clk_freq = 100 generate
-    clkgen100: entity work.pll_50M_100M_25M_250M
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk, clk_out2 => clk_25MHz, clk_out3 => clk_250MHz
-    );
-    end generate;
+	clk100: if C_clk_freq = 100 generate
+	clkgen100: entity work.pll_50M_100M_25M_250M
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk, clk_out2 => clk_25MHz, clk_out3 => clk_250MHz
+	);
+	end generate;
 
-    clk83: if C_clk_freq = 83 generate
-    clkgen83: entity work.pll_50M_25M_83M33_250M
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk_25MHz, clk_out2 => clk, clk_out3 => clk_250MHz
-    );
-    end generate;
+	clk83: if C_clk_freq = 83 generate
+	clkgen83: entity work.pll_50M_25M_83M33_250M
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk_25MHz, clk_out2 => clk, clk_out3 => clk_250MHz
+	);
+	end generate;
 
-    clk81: if C_clk_freq = 81 generate
-    clkgen81: entity work.pll_50M_81M25
-    port map(
-      clk_in1 => clk_50MHz, clk_out1 => clk
-    );
-    end generate;
+	clk81: if C_clk_freq = 81 generate
+	clkgen81: entity work.pll_50M_81M25
+	port map(
+	  clk_in1 => clk_50MHz, clk_out1 => clk
+	);
+	end generate;
 
-    clk50: if C_clk_freq = 50 generate
-      clk <= clk_50MHz;
-    end generate;
+	clk50: if C_clk_freq = 50 generate
+	  clk <= clk_50MHz;
+	end generate;
 
-    -- reset hard-block: Xilinx Spartan-6 specific
-    reset: startup_spartan6
-    port map (
+	-- reset hard-block: Xilinx Spartan-6 specific
+	reset: startup_spartan6
+	port map (
 	clk => clk, gsr => rs232_break, gts => rs232_break,
 	keyclearb => '0'
-    );
+	);
 
-    -- generic SDRAM glue
-    glue_sdram: entity work.glue_sdram
-    generic map (
+	-- generic SDRAM glue
+	glue_sdram: entity work.glue_sdram
+	generic map (
 	C_arch => C_arch,
 	C_clk_freq => C_clk_freq,
 	C_mem_size => C_mem_size,
@@ -172,13 +192,31 @@ begin
 	C_sdram_separate_arbiter => C_sdram_separate_arbiter,
 	C_ram_emu_addr_width => C_ram_emu_addr_width,
 	C_ram_emu_wait_states => C_ram_emu_wait_states,
-        C_vgahdmi => C_vgahdmi,
-        C_vgatext => C_vgatext,
+	C_vgahdmi => C_vgahdmi,
+	C_vgatext => C_vgatext,
 	C_vgatext_label => C_vgatext_label,
+	C_vgatext_mode => C_vgatext_mode,
+	C_vgatext_bits => C_vgatext_bits,
+	C_vgatext_mem => C_vgatext_mem,
+	C_vgatext_palette => C_vgatext_palette,
+	C_vgatext_text => C_vgatext_text,
+	C_vgatext_monochrome => C_vgatext_monochrome,
+	C_vgatext_font_height => C_vgatext_font_height,
+	C_vgatext_char_height => C_vgatext_char_height,
+	C_vgatext_font_linedouble => C_vgatext_font_linedouble,
+	C_vgatext_font_depth => C_vgatext_font_depth,
+	C_vgatext_text_fifo => C_vgatext_text_fifo,
+	C_vgatext_text_fifo_step => C_vgatext_text_fifo_step,
+	C_vgatext_text_fifo_width => C_vgatext_text_fifo_width,
+	C_vgatext_bitmap => C_vgatext_bitmap,
+	C_vgatext_bitmap_depth => C_vgatext_bitmap_depth,
+	C_vgatext_bitmap_fifo => C_vgatext_bitmap_fifo,
+	C_vgatext_bitmap_fifo_step => C_vgatext_bitmap_fifo_step,
+	C_vgatext_bitmap_fifo_width => C_vgatext_bitmap_fifo_width,
 	C_fmrds => C_fmrds,
 	C_debug => C_debug
-    )
-    port map (
+	)
+	port map (
 	clk => clk,
 	clk_25MHz => clk_25MHz, -- pixel clock
 	clk_250MHz => clk_250MHz, -- tmds clock
@@ -206,37 +244,37 @@ begin
 	simple_in(15 downto 0) => open,
 	simple_in(19 downto 16) => sw(4 downto 1),
 	simple_in(31 downto 20) => open
-    );
+	);
 
-    -- SDRAM clock output needs special routing on Spartan-6
-    sdram_clk_forward : ODDR2
-    generic map(
+	-- SDRAM clock output needs special routing on Spartan-6
+	sdram_clk_forward : ODDR2
+	generic map(
 	DDR_ALIGNMENT => "NONE", INIT => '0', SRTYPE => "SYNC"
-    )
-    port map (
+	)
+	port map (
 	Q => sdram_clk, C0 => clk, C1 => sdram_clk_internal, CE => '1',
 	R => '0', S => '0', D0 => '0', D1 => '1'
-    );
+	);
 
-    -- differential output buffering for HDMI clock and video
-    hdmi_output1: entity work.hdmi_out
-      port map (
-        tmds_in_clk    => clk_25MHz,
-        tmds_out_clk_p => tmds_out_clk_p,
-        tmds_out_clk_n => tmds_out_clk_n,
-        tmds_in_rgb    => tmds_out_rgb,
-        tmds_out_rgb_p => tmds_out_p,
-        tmds_out_rgb_n => tmds_out_n
-      );
+	-- differential output buffering for HDMI clock and video
+	hdmi_output1: entity work.hdmi_out
+	  port map (
+		tmds_in_clk    => clk_25MHz,
+		tmds_out_clk_p => tmds_out_clk_p,
+		tmds_out_clk_n => tmds_out_clk_n,
+		tmds_in_rgb    => tmds_out_rgb,
+		tmds_out_rgb_p => tmds_out_p,
+		tmds_out_rgb_n => tmds_out_n
+	  );
 
-    hdmi_output2: entity work.hdmi_out
-      port map (
-        tmds_in_clk    => clk_25MHz,
-        tmds_out_clk_p => tmds_in_clk_p,
-        tmds_out_clk_n => tmds_in_clk_n,
-        tmds_in_rgb    => tmds_out_rgb,
-        tmds_out_rgb_p => tmds_in_p,
-        tmds_out_rgb_n => tmds_in_n
-      );
+	hdmi_output2: entity work.hdmi_out
+	  port map (
+		tmds_in_clk    => clk_25MHz,
+		tmds_out_clk_p => tmds_in_clk_p,
+		tmds_out_clk_n => tmds_in_clk_n,
+		tmds_in_rgb    => tmds_out_rgb,
+		tmds_out_rgb_p => tmds_in_p,
+		tmds_out_rgb_n => tmds_in_n
+	  );
 
 end Behavioral;


### PR DESCRIPTION
…t to show dependent options. Verify all generics are set and passed through.  Modify glue defaults to be minimal resources. Modify toplevel miniSpartan6+ bram and sdram to nicer defaults.  Tested with 'boulder'. :-)

What do you think of this?  BTW, I also fixed a 'bug' where I was doubling lines on 16 high font, which was making 'boulder' look ugly.  Much nicer with proper 8x16 font, :-)

It also seems I altered some spaces to tabs in these files (hope this is okay - I may need to change editor settings if not).  I believe you mentioned that 4 space tab indents was the f32c "standard" (which is what I am using).