### PR TITLE
Fixed a few VHDL-93 compliance issues

### DIFF
--- a/rtl/generic/glue_bram.vhd
+++ b/rtl/generic/glue_bram.vhd
@@ -390,6 +390,8 @@ begin
     -- Debugging SIO instance
     G_debug_sio:
     if C_debug generate
+      signal bus_out : std_logic_vector(31 downto 0);
+    begin
     debug_sio: entity work.sio
     generic map (
 	C_clk_freq => C_clk_freq,
@@ -400,11 +402,12 @@ begin
 	bus_write => deb_sio_tx_strobe, byte_sel => "0001",
 	bus_in(7 downto 0) => debug_to_sio_data,
 	bus_in(31 downto 8) => x"000000",
-	bus_out(7 downto 0) => sio_to_debug_data,
-	bus_out(8) => deb_sio_rx_done, bus_out(9) => open,
-	bus_out(10) => deb_sio_tx_busy, bus_out(31 downto 11) => open,
-	break => open
+        bus_out => bus_out, break => open
     );
+
+    sio_to_debug_data <= bus_out(7 downto 0);
+    deb_sio_rx_done <= bus_out(8);
+    deb_sio_tx_busy <= bus_out(10);
     end generate;
 
     sio_txd(0) <= sio_tx(0) when not C_debug or debug_active = '0' else deb_tx;

--- a/rtl/generic/sram_emu.vhd
+++ b/rtl/generic/sram_emu.vhd
@@ -54,8 +54,11 @@ architecture Structure of sram_emu is
     -- SRAM emulation signals for internal BRAM
     signal sram_we_lower, sram_we_upper: std_logic;
     signal from_sram_lower, from_sram_upper: std_logic_vector(7 downto 0);
+    signal clk_n : std_logic;
 begin
 
+    clk_n <= not clk;
+  
     sram_emul_lower: entity work.bram_true2p_1clk
     generic map (
         dual_port => false,
@@ -63,7 +66,7 @@ begin
         addr_width => C_addr_width
     )
     port map (
-        clk => not clk,
+        clk => clk_n,
         we_a => sram_we_lower,
         addr_a => sram_a(C_addr_width-1 downto 0),
         data_in_a => sram_d(7 downto 0), data_out_a => from_sram_lower,
@@ -78,7 +81,7 @@ begin
         addr_width => C_addr_width
     )
     port map (
-        clk => not clk,
+        clk => clk_n,
         we_a => sram_we_upper,
         addr_a => sram_a(C_addr_width-1 downto 0),
         data_in_a => sram_d(15 downto 8), data_out_a => from_sram_upper,


### PR DESCRIPTION
I am trying to get a minimal example compiling, and ran into a few compile issues, at least some of which are allowed in VHDL-2008 but not in VHDL-93.  The fixes were easy, so I reworked for backward compatibility.