### PR TITLE
Initialised ID_EX_bubble to allow reset exception to take place.

### DIFF
--- a/rtl/cpu/pipeline.vhd
+++ b/rtl/cpu/pipeline.vhd
@@ -842,6 +842,7 @@ begin
 	    end if;
 	    if R_reset = '1' then
 		ID_EX_exception <= true;
+		ID_EX_bubble <= false;
 	    end if;
 	end if;
     end process;


### PR DESCRIPTION
In MIPS mode, the initial PC can be specified with generics, but is sometimes ignored, with the CPU starting at 0x0000000 instead of the requested address. 

The initial PC is set by placing the start address in k0, triggering an exception, and feeding the CPU with an instruction to jump to k0's contents - however this logic only happens if the ID_EX_bubble signal is false in the cycles immediately following reset.  Since ID_EX_bubble isn't initialised, its state at powerup is random and varies from build to build.

This one-line patch simply initialises the ID_EX_bubble signal to false at reset.